### PR TITLE
Non root version and interactive menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# ide
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/home/anatolio/Projects/forks/venv/bin/python3.9"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/home/anatolio/Projects/forks/venv/bin/python3.9"
-}

--- a/v2sub/__init__.py
+++ b/v2sub/__init__.py
@@ -3,7 +3,7 @@ import os
 __version__ = '1.1'
 
 # define all global variables in here
-user = os.getenv("SUDO_USER") or os.getenv("USER")
+user = os.getenv("USER")
 BASE_PATH = os.path.join(os.path.expanduser("~%s" % user), ".v2sub")
 SUBSCRIBE_CONFIG = os.path.join(BASE_PATH, 'subscribes.json')
 SERVER_CONFIG = os.path.join(BASE_PATH, 'servers.json')

--- a/v2sub/config.py
+++ b/v2sub/config.py
@@ -1,6 +1,6 @@
 from v2sub import utils
 
-V2RAY_CONFIG_FILE = "/etc/v2ray/config.json"
+V2RAY_CONFIG_FILE = "/tmp/config.json"
 
 
 def _get_config(addr: str, port: int, id_: str, client_port=1080) -> dict:

--- a/v2sub/systemd.py
+++ b/v2sub/systemd.py
@@ -1,0 +1,46 @@
+
+from subprocess import CalledProcessError, run
+from typing import Iterable
+from v2sub import BASE_PATH
+import os
+
+SYSTEMD_UNIT = os.path.join(BASE_PATH, 'unit.json')
+SYSTEMD_RUN_CMD = [
+            "systemd-run",
+            "--user",
+            "--collect",
+            "-p",
+            "Restart=on-failure",
+        ]
+
+def start(cmd: Iterable) -> dict:
+        SYSTEMD_RUN_CMD.extend(cmd)
+
+        proc = run(
+            SYSTEMD_RUN_CMD,
+            check=True,
+            capture_output=True,
+        )
+
+        return {"unit": proc.stderr.decode().split(":")[1].strip()}
+
+def is_active(unit: str) -> bool:
+    try:
+        proc = run(
+            ["systemctl", "--user", "is-active", unit],
+            check=True,
+            capture_output=True,
+        )
+    except CalledProcessError:
+        return False
+    else:
+        if "active" in proc.stdout.decode():
+            return True
+    return False
+
+def stop(unit: str) -> None:
+    run(
+        ["systemctl", "--user", "stop", unit],
+        check=False,
+        capture_output=True
+    )

--- a/v2sub/utils.py
+++ b/v2sub/utils.py
@@ -1,7 +1,7 @@
 import json
 import re
 import sys
-from subprocess import call, Popen, PIPE
+from subprocess import Popen, PIPE
 
 import click
 
@@ -44,14 +44,6 @@ def echo_node(index, node, delay=None):
     click.echo(s)
 
 
-def restart_server():
-    click.echo("Going to restart v2ray service...")
-    result = call("systemctl restart v2ray.service", shell=True)
-    if result == 0:
-        click.echo("Done...")
-    else:
-        click.echo("Error...")
-
 
 def _ping(ip, times=3, timeout=1, interval=0.2):
     cmd = [
@@ -80,15 +72,11 @@ def ping(name=DEFAULT_SUBSCRIBE, index=None, all_servers=None):
         click.echo("Unknown subscribe: %s, please check it." % name)
         sys.exit(1)
     if index is not None:
-        try:
-            check_index(index)
-            node = servers[index - 1]
-        except IndexError:
-            click.echo("Invalid index: %s, please check it." % index)
-            sys.exit(1)
+        node = servers[index]
         delay = _ping(node['add'])
         echo_node(index, node, delay=delay)
     else:
         for index, node in enumerate(servers, start=1):
             delay = _ping(node['add'])
             echo_node(index, node, delay=delay)
+


### PR DESCRIPTION
We can avoid using root to manage the systemd service by using [systemd-run](https://www.freedesktop.org/software/systemd/man/systemd-run.html).

It will create a _transient_ systemd unit and save its name to `unit.json`.

### The benefits

- No-root
- More reliable systemd service with _Restart=on-failure_ option
- Ability to check whether service is running with a `systemd status <unit_name>` command (See `unit.json`)
- We can stop systemd service at any time using `systemd stop <unit_name>` command (See `unit.json`)

The functionality mentioned above is located at `systemd.py`.

### Other features
- Interactive menu via [simple-term-menu](https://pypi.org/project/simple-term-menu/) package
- Don't restart the systemd service if the user tries to connect to the same server